### PR TITLE
Add configurable crop saving

### DIFF
--- a/config.yaml-sample
+++ b/config.yaml-sample
@@ -27,4 +27,10 @@ settings:
   bib_categories: ["5K", "21K", "42K"]
   bib_colours: ""
 
+output:
+  save_crops: false
+  path: output
+  min_confidence: 0.5
+  save_uncertain: true
+
 gemini_api_key: <INSERT KEY>


### PR DESCRIPTION
## Summary
- allow configuring saving crops in config
- implement `_save_shoe_crop` for saving shoes
- update sample config with output options

## Testing
- `python -m py_compile detector.py`

------
https://chatgpt.com/codex/tasks/task_e_684ffea5900c8321a86170d9d1b045b0